### PR TITLE
change buffer initialization, remove usage of new Buffer

### DIFF
--- a/lib/buffer-writer.js
+++ b/lib/buffer-writer.js
@@ -37,7 +37,7 @@ module.exports = function () {
         double(val) {
             var buff;
 
-            buff = new Buffer(8);
+            buff = Buffer.alloc(8);
             buff.writeDoubleBE(val);
             this.bufferList.push(buff);
         }
@@ -85,7 +85,7 @@ module.exports = function () {
          * @param {string} str
          */
         string(str) {
-            this.bufferList.push(new Buffer(str, "binary"));
+            this.bufferList.push(Buffer.from(str, "binary"));
         }
 
 
@@ -107,7 +107,7 @@ module.exports = function () {
         uint8(val) {
             var buff;
 
-            buff = new Buffer(1);
+            buff = Buffer.alloc(1);
             buff.writeUInt8(val);
             this.bufferList.push(buff);
         }
@@ -121,7 +121,7 @@ module.exports = function () {
         uint16(val) {
             var buff;
 
-            buff = new Buffer(2);
+            buff = Buffer.alloc(2);
             buff.writeUInt16BE(val);
             this.bufferList.push(buff);
         }
@@ -135,7 +135,7 @@ module.exports = function () {
         uint32(val) {
             var buff;
 
-            buff = new Buffer(4);
+            buff = Buffer.alloc(4);
             buff.writeUInt32BE(val);
             this.bufferList.push(buff);
         }

--- a/spec/buffer-reader.spec.js
+++ b/spec/buffer-reader.spec.js
@@ -24,7 +24,7 @@ describe("BufferReader", () => {
             var br;
 
             expect(() => {
-                br = new BufferReader(new Buffer(1), 0);
+                br = new BufferReader(Buffer.alloc(1), 0);
             }).not.toThrow();
             expect(br[methodName]).toEqual(jasmine.any(Function));
         });
@@ -32,7 +32,7 @@ describe("BufferReader", () => {
     it("reads a buffer", () => {
         var br, buff;
 
-        br = new BufferReader(new Buffer("abcdefg"), 3);
+        br = new BufferReader(Buffer.from("abcdefg"), 3);
         buff = br.buffer(2);
         expect(buff.length).toBe(2);
         expect(buff.toString("binary")).toBe("de");
@@ -43,7 +43,7 @@ describe("BufferReader", () => {
     it("reads a double", () => {
         var br, buff;
 
-        buff = new Buffer(16);
+        buff = Buffer.alloc(16);
         buff.fill(0x42);
         buff[0] = 0x3F;
         buff[1] = 0;
@@ -60,7 +60,7 @@ describe("BufferReader", () => {
     it("peeks and skips", () => {
         var br;
 
-        br = new BufferReader(new Buffer("abcd"), 2);
+        br = new BufferReader(Buffer.from("abcd"), 2);
         expect(br.peek()).toBe("c".charCodeAt(0));
 
         // Pointer does not advance with this method
@@ -79,7 +79,7 @@ describe("BufferReader", () => {
     it("reads different sized sizes", () => {
         var br, buff;
 
-        buff = new Buffer(7);
+        buff = Buffer.alloc(7);
         buff[0] = 0x01;  // 1 byte
         buff[1] = 0x80;
         buff[2] = 0x02;  // 2 bytes
@@ -95,14 +95,14 @@ describe("BufferReader", () => {
     it("reads a string", () => {
         var br;
 
-        br = new BufferReader(new Buffer("abcdefghijklm"), 4);
+        br = new BufferReader(Buffer.from("abcdefghijklm"), 4);
         expect(br.string(5)).toBe("efghi");
         expect(br.string(3)).toBe("jkl");
     });
     it("reads different sized integers", () => {
         var br, buff;
 
-        buff = new Buffer(7);
+        buff = Buffer.alloc(7);
         buff[0] = 0x01;  // 1 byte
         buff[1] = 0x80;
         buff[2] = 0x02;  // 2 bytes

--- a/spec/buffer-writer.spec.js
+++ b/spec/buffer-writer.spec.js
@@ -32,8 +32,8 @@ describe("BufferWriter", () => {
         var buff, bw;
 
         bw = new BufferWriter();
-        bw.buffer(new Buffer("abc"));
-        bw.buffer(new Buffer("defghi"));
+        bw.buffer(Buffer.from("abc"));
+        bw.buffer(Buffer.from("defghi"));
         buff = bw.toBuffer();
         expect(buff).toEqual(jasmine.any(Buffer));
         expect(buff.toString("binary")).toEqual("abcdefghi");

--- a/spec/serializer.spec.js
+++ b/spec/serializer.spec.js
@@ -53,7 +53,7 @@ describe("serializer", () => {
         {
             bufferHex: "420474657374",
             name: "0x42 B Buffer object",
-            raw: new Buffer("test")
+            raw: Buffer.from("test")
         },
         {
             bufferHex: "44568672700001",
@@ -149,7 +149,7 @@ describe("serializer", () => {
         it("deserializes: " + scenario.name, () => {
             var buff, result;
 
-            buff = new Buffer("00" + scenario.bufferHex, "hex");
+            buff = Buffer.from("00" + scenario.bufferHex, "hex");
             result = serializer.fromBuffer(buff);
 
             if (Buffer.isBuffer(scenario.raw)) {
@@ -161,7 +161,7 @@ describe("serializer", () => {
         it("deserializes internally: " + scenario.name, () => {
             var br, buff, result;
 
-            buff = new Buffer(scenario.bufferHex, "hex");
+            buff = Buffer.from(scenario.bufferHex, "hex");
             br = new BufferReader(buff);
             result = serializer.fromBufferInternal(br);
 
@@ -175,12 +175,12 @@ describe("serializer", () => {
     describe("with bad input", () => {
         it("fails with non-zero version identifier", () => {
             expect(() => {
-                serializer.fromBuffer(new Buffer("0174", "hex"));
+                serializer.fromBuffer(Buffer.from("0174", "hex"));
             }).toThrow();
         });
         it("errors when encountering an invalid code", () => {
             expect(() => {
-                serializer.fromBufferInternal(new Buffer("00", "hex"));
+                serializer.fromBufferInternal(Buffer.from("00", "hex"));
             }).toThrow();
         });
         it("errors when a helper is not found", () => {
@@ -188,7 +188,7 @@ describe("serializer", () => {
                 var buffReader;
 
                 // Looks for a helper named "x"
-                buffReader = new BufferReader(new Buffer("5A0178", "hex"));
+                buffReader = new BufferReader(Buffer.from("5A0178", "hex"));
                 serializer.fromBufferInternal(buffReader);
             }).toThrow();
         });
@@ -233,7 +233,7 @@ describe("serializer", () => {
         it("deserializes a custom class", () => {
             var k;
 
-            k = serializer.fromBuffer(new Buffer("005A054B6C61737302", "hex"));
+            k = serializer.fromBuffer(Buffer.from("005A054B6C61737302", "hex"));
             expect(k).toEqual(jasmine.any(Klass));
             expect(k.getVal()).toEqual(2);
         });


### PR DESCRIPTION
### Remove usage of new Buffer

[Node.js: The Buffer() function and new Buffer() constructor are deprecated due to API usability issues that can lead to accidental security issues.](https://nodejs.dev/en/api/v18/deprecations/#dep0005-buffer-constructor)

[Stackoverflow:  DeprecationWarning: Buffer() is deprecated due to security and usability issues](https://stackoverflow.com/questions/52165333/deprecationwarning-buffer-is-deprecated-due-to-security-and-usability-issues)

**Environment**

Node Version: v19.7.0

**Current Behaviour:**

```
npm test

> buffer-serializer@1.1.0 test
> jasmine-node lib spec

(node:93708) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
...................................................................................................................

Finished in 0.021 seconds
115 tests, 181 assertions, 0 failures, 0 skipped
```

**Expected Behaviour:**

```
npm test                    

> buffer-serializer@1.1.0 test
> jasmine-node lib spec

...................................................................................................................

Finished in 0.018 seconds
115 tests, 181 assertions, 0 failures, 0 skipped
```